### PR TITLE
chore(release): v1.5.0 — Band-limited false-positive gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## v1.5.0 (2026-06-14) — Band-limited false-positive gate
 
 - **Fewer false positives on band-limited music (Rule 1 near-Nyquist gate).** A 320 kbps
   MP3 low-passes at ~20.5 kHz — exactly where genuinely band-limited lossless (baroque,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flac-detective"
-version = "1.4.0"
+version = "1.5.0"
 description = "Advanced FLAC authenticity analyzer - Detects MP3-to-FLAC transcodes with high precision"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -194,7 +194,7 @@ disable = [
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "1.4.0"
+version = "1.5.0"
 tag_format = "v$version"
 update_changelog_on_bump = false
 version_files = [

--- a/src/flac_detective/__version__.py
+++ b/src/flac_detective/__version__.py
@@ -4,12 +4,12 @@ This is the single source of truth for the version number.
 All other files should reference this file.
 """
 
-__version__ = "1.4.0"
+__version__ = "1.5.0"
 __version_info__ = tuple(int(x) for x in __version__.split("."))
 
 # Release information
-__release_date__ = "2026-06-10"
-__release_name__ = "Beets plugin + English-only output"
+__release_date__ = "2026-06-14"
+__release_name__ = "Band-limited false-positive gate"
 
 # Metadata
 __author__ = "Guillain d'Erceville"


### PR DESCRIPTION
Release bump for v1.5.0. Promotes the CHANGELOG `Unreleased` section (the Rule 1 near-Nyquist wall-hardness gate, #2) and bumps the version in `pyproject.toml` + `__version__.py`.

Minor bump: detection behaviour changes (near-Nyquist 320 kbps false positives on band-limited material now read AUTHENTIC) but the public API — CLI flags, top-level exports, `analyze_file()` result-dict keys — is unchanged.

Tagging `v1.5.0` after this merges triggers the release automation (wheel → PyPI, Docker → GHCR, docs).
